### PR TITLE
Add configurable I2C addresses

### DIFF
--- a/Adafruit_FXOS8700.cpp
+++ b/Adafruit_FXOS8700.cpp
@@ -116,8 +116,7 @@ byte Adafruit_FXOS8700::read8(byte reg) {
     @param addr The I2C address of the sensor.
 */
 /**************************************************************************/
-Adafruit_FXOS8700::Adafruit_FXOS8700(int32_t accelSensorID,
-                                     int32_t magSensorID,
+Adafruit_FXOS8700::Adafruit_FXOS8700(int32_t accelSensorID, int32_t magSensorID,
                                      byte addr) {
   _accelSensorID = accelSensorID;
   _magSensorID = magSensorID;

--- a/Adafruit_FXOS8700.cpp
+++ b/Adafruit_FXOS8700.cpp
@@ -64,7 +64,7 @@
 */
 /**************************************************************************/
 void Adafruit_FXOS8700::write8(byte reg, byte value) {
-  Wire.beginTransmission(FXOS8700_ADDRESS);
+  Wire.beginTransmission(_sensorAddr);
 #if ARDUINO >= 100
   Wire.write((uint8_t)reg);
   Wire.write((uint8_t)value);
@@ -84,7 +84,7 @@ void Adafruit_FXOS8700::write8(byte reg, byte value) {
 byte Adafruit_FXOS8700::read8(byte reg) {
   byte value;
 
-  Wire.beginTransmission((byte)FXOS8700_ADDRESS);
+  Wire.beginTransmission((byte)_sensorAddr);
 #if ARDUINO >= 100
   Wire.write((uint8_t)reg);
 #else
@@ -92,7 +92,7 @@ byte Adafruit_FXOS8700::read8(byte reg) {
 #endif
   if (Wire.endTransmission(false) != 0)
     return 0;
-  Wire.requestFrom((byte)FXOS8700_ADDRESS, (byte)1);
+  Wire.requestFrom((byte)_sensorAddr, (byte)1);
 #if ARDUINO >= 100
   value = Wire.read();
 #else
@@ -113,12 +113,15 @@ byte Adafruit_FXOS8700::read8(byte reg) {
 
     @param accelSensorID The unique ID to associate with the accelerometer.
     @param magSensorID The unique ID to associate with the magnetometer.
+    @param addr The I2C address of the sensor.
 */
 /**************************************************************************/
 Adafruit_FXOS8700::Adafruit_FXOS8700(int32_t accelSensorID,
-                                     int32_t magSensorID) {
+                                     int32_t magSensorID,
+                                     byte addr) {
   _accelSensorID = accelSensorID;
   _magSensorID = magSensorID;
+  _sensorAddr = addr;
 
   accel_sensor = new Adafruit_FXOS8700_Accelerometer(this);
   mag_sensor = new Adafruit_FXOS8700_Magnetometer(this);
@@ -215,14 +218,14 @@ bool Adafruit_FXOS8700::getEvent(sensors_event_t *accelEvent,
                                  sensors_event_t *magEvent) {
 
   /* Read 13 bytes from the sensor */
-  Wire.beginTransmission((byte)FXOS8700_ADDRESS);
+  Wire.beginTransmission((byte)_sensorAddr);
 #if ARDUINO >= 100
   Wire.write(FXOS8700_REGISTER_STATUS | 0x80);
 #else
   Wire.send(FXOS8700_REGISTER_STATUS | 0x80);
 #endif
   Wire.endTransmission();
-  Wire.requestFrom((byte)FXOS8700_ADDRESS, (byte)13);
+  Wire.requestFrom((byte)_sensorAddr, (byte)13);
 
 /* ToDo: Check status first! */
 #if ARDUINO >= 100

--- a/Adafruit_FXOS8700.h
+++ b/Adafruit_FXOS8700.h
@@ -34,7 +34,7 @@
     I2C ADDRESS/BITS AND SETTINGS
     -----------------------------------------------------------------------*/
 /** 7-bit I2C address for this sensor */
-#define FXOS8700_ADDRESS (0x1F) // 0011111
+// #define FXOS8700_ADDRESS (0x1F) // 0011111
 /** Device ID for this sensor (used as sanity check during init) */
 #define FXOS8700_ID (0xC7) // 1100 0111
 /*=========================================================================*/
@@ -151,7 +151,7 @@ private:
 /**************************************************************************/
 class Adafruit_FXOS8700 : public Adafruit_Sensor {
 public:
-  Adafruit_FXOS8700(int32_t accelSensorID = -1, int32_t magSensorID = -1);
+  Adafruit_FXOS8700(int32_t accelSensorID = -1, int32_t magSensorID = -1, byte addr = 0x1F);
 
   bool begin(fxos8700AccelRange_t rng = ACCEL_RANGE_2G);
   bool getEvent(sensors_event_t *accel);
@@ -177,6 +177,7 @@ private:
   byte read8(byte reg);
 
   fxos8700AccelRange_t _range;
+  byte _sensorAddr;
   int32_t _accelSensorID;
   int32_t _magSensorID;
 };

--- a/Adafruit_FXOS8700.h
+++ b/Adafruit_FXOS8700.h
@@ -151,7 +151,8 @@ private:
 /**************************************************************************/
 class Adafruit_FXOS8700 : public Adafruit_Sensor {
 public:
-  Adafruit_FXOS8700(int32_t accelSensorID = -1, int32_t magSensorID = -1, byte addr = 0x1F);
+  Adafruit_FXOS8700(int32_t accelSensorID = -1, int32_t magSensorID = -1,
+                    byte addr = 0x1F);
 
   bool begin(fxos8700AccelRange_t rng = ACCEL_RANGE_2G);
   bool getEvent(sensors_event_t *accel);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit FXOS8700
-version=1.4.0
+version=1.5.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Unified sensor driver for the FXOS8700 Accelerometer/Magnetometer


### PR DESCRIPTION
This allows the class to work on other addresses configured with the SA0/1 pins on the FXOS8700. It still defaults to the current address as configured by Adafruit's 9-axis board, and was implemented such that any code currently working with this class will still function as-is. 

This configuration option on other Sensor libraries is implemented as part of the `begin()` method. However, implementing it here would have possible breaking-change possibilities given there's already a configuration option in this method. I am open to thoughts on placing it here to be more standardized.

I have tested with the Freescale Freedom board with these devices on it with a Grand Central M4, because those are the boards I have, but the logical structure is all still the same so shouldn't impact the operation previously.