### PR TITLE
Feature odr setting

### DIFF
--- a/Adafruit_FXOS8700.cpp
+++ b/Adafruit_FXOS8700.cpp
@@ -65,12 +65,14 @@ bool Adafruit_FXOS8700::initialize() {
   /* Set to standby mode (required to make changes to this register) */
   CTRL_REG1.write(0x00);
 
-  /* Set the full scale range of the sensor here during first standby. Default 2G */
+  /* Set the full scale range of the sensor here during first standby. Default
+   * 2G */
   XYZ_DATA_CFG.write(ACCEL_MG_LSB_2G);
 
   /* High resolution */
   CTRL_REG2.write(0x02);
-  /* Active, Normal Mode, Low Noise, Hybrid Mode rate setting as specified. Default 100Hz */
+  /* Active, Normal Mode, Low Noise, Hybrid Mode rate setting as specified.
+   * Default 100Hz */
   CTRL_REG1.write(ODR_HYBRID_100HZ);
 
   /* Configure the magnetometer */
@@ -148,7 +150,7 @@ bool Adafruit_FXOS8700::begin(uint8_t addr, TwoWire *wire) {
   Adafruit_BusIO_Register WHO_AM_I(i2c_dev, FXOS8700_REGISTER_WHO_AM_I);
   if (WHO_AM_I.read() != FXOS8700_ID)
     return false;
-  
+
   return initialize();
 }
 
@@ -406,11 +408,8 @@ void Adafruit_FXOS8700::setAccelRange(fxos8700AccelRange_t range) {
   Adafruit_BusIO_Register XYZ_DATA_CFG(i2c_dev, FXOS8700_REGISTER_XYZ_DATA_CFG);
   Adafruit_BusIO_RegisterBits fs_bits(&XYZ_DATA_CFG, 2, 0);
 
-  uint8_t mask = (range << 2) - 1;
-  uint8_t rangeBits = range & mask;
-
   standby(true);
-  fs_bits.write(rangeBits);
+  fs_bits.write(range);
   standby(false);
 
   _range = range;
@@ -453,7 +452,6 @@ void Adafruit_FXOS8700::setHybridODR(fxos8700HybridODR_t rate) {
 */
 /**************************************************************************/
 fxos8700HybridODR_t Adafruit_FXOS8700::getHybridODR() { return _rate; }
-
 
 /**************************************************************************/
 /*!

--- a/Adafruit_FXOS8700.cpp
+++ b/Adafruit_FXOS8700.cpp
@@ -338,6 +338,8 @@ bool Adafruit_FXOS8700::getEvent(sensors_event_t *singleSensorEvent) {
     return getEvent(singleSensorEvent, &dummy);
   case MAG_ONLY_MODE:
     return getEvent(&dummy, singleSensorEvent);
+  default:
+    return false;
   }
 }
 

--- a/Adafruit_FXOS8700.cpp
+++ b/Adafruit_FXOS8700.cpp
@@ -66,7 +66,7 @@ bool Adafruit_FXOS8700::initialize() {
 
   /* Low Noise & High accelerometer OSR resolution */
   standby(true);
-  lnoise_bit.write(0x04);
+  lnoise_bit.write(0x01);
   mods_bits.write(0x02);
   standby(false);
 

--- a/Adafruit_FXOS8700.h
+++ b/Adafruit_FXOS8700.h
@@ -86,14 +86,14 @@ typedef enum {
     Maintains lnoise and active bits as 1
 */
 typedef enum {
-  ODR_HYBRID_400HZ = 0x05,    /**< 400Hz Hybrid mode */
-  ODR_HYBRID_200HZ = 0x0D,    /**< 200Hz Hybrid mode */
-  ODR_HYBRID_100HZ = 0x15,    /**< 100Hz Hybrid mode */
-  ODR_HYBRID_50HZ = 0x1D,     /**< 50Hz Hybrid mode */
-  ODR_HYBRID_25HZ = 0x25,     /**< 25Hz Hybrid mode */
-  ODR_HYBRID_6_25HZ = 0x2D,   /**< 6.25Hz Hybrid mode */
-  ODR_HYBRID_3_125HZ = 0x35,  /**< 3.125Hz Hybrid mode */
-  ODR_HYBRID_0_7813HZ = 0x3D  /**< 0.7813Hz Hybrid mode */
+  ODR_HYBRID_400HZ = 0x05,   /**< 400Hz Hybrid mode */
+  ODR_HYBRID_200HZ = 0x0D,   /**< 200Hz Hybrid mode */
+  ODR_HYBRID_100HZ = 0x15,   /**< 100Hz Hybrid mode */
+  ODR_HYBRID_50HZ = 0x1D,    /**< 50Hz Hybrid mode */
+  ODR_HYBRID_25HZ = 0x25,    /**< 25Hz Hybrid mode */
+  ODR_HYBRID_6_25HZ = 0x2D,  /**< 6.25Hz Hybrid mode */
+  ODR_HYBRID_3_125HZ = 0x35, /**< 3.125Hz Hybrid mode */
+  ODR_HYBRID_0_7813HZ = 0x3D /**< 0.7813Hz Hybrid mode */
 } fxos8700HybridODR_t;
 /*=========================================================================*/
 

--- a/Adafruit_FXOS8700.h
+++ b/Adafruit_FXOS8700.h
@@ -49,6 +49,7 @@ typedef enum {
   FXOS8700_REGISTER_OUT_Y_LSB = 0x04, /**< 0x04 */
   FXOS8700_REGISTER_OUT_Z_MSB = 0x05, /**< 0x05 */
   FXOS8700_REGISTER_OUT_Z_LSB = 0x06, /**< 0x06 */
+  FXOS8600_REGISTER_SYSMOD = 0x0B,    /**< 0x0B */
   FXOS8700_REGISTER_WHO_AM_I =
       0x0D, /**< 0x0D (default value = 0b11000111, read only) */
   FXOS8700_REGISTER_XYZ_DATA_CFG = 0x0E, /**< 0x0E */
@@ -79,22 +80,96 @@ typedef enum {
 /*=========================================================================*/
 
 /*=========================================================================
+    OPTIONAL SENSOR MODE SETTINGS
+    -----------------------------------------------------------------------*/
+/*!
+    System status for the overall FXOS8700 sensor. Gets the current mode as
+    the 2bit sysmod[1:0] setting to ensure proper mode configuration
+*/
+typedef enum {
+  STANDBY = 0x00, /**< sysmod[1:0]. Standby status */
+  WAKE = 0x01,    /**< sysmod[1:0]. Wake status */
+  SLEEP = 0x02    /**< sysmod[1:0]. Sleep status */
+} fxos8700SystemStatus_t;
+
+/*!
+    Sensor mode seetings for the overall FXOS8700 sensor. Sets the sensor in
+    accelerometer-only, magnerometer-only, or hybrid modes. Sent to
+    FXOS8700_REGISTER_MCTRL_REG1
+*/
+typedef enum {
+  ACCEL_ONLY_MODE = 0b00, /**< m_hms[1:0] = 0b00. Accel-only mode */
+  MAG_ONLY_MODE = 0b01,   /**< m_hms[1:0] = 0b01. Mag-only mode */
+  HYBRID_MODE = 0b11      /**< m_hms[1:0] = 0b11. Hybrid mode */
+} fxos8700SensorMode_t;
+/*=========================================================================*/
+
+/*=========================================================================
     OPTIONAL SPEED SETTINGS
     -----------------------------------------------------------------------*/
 /*!
-    Output Data Rate (ODR) settings for the overall FXOS8700 sensor.
-    Maintains lnoise and active bits as 1
+    Output Data Rate (ODR) key for the overall FXOS8700 sensor. Called by
+    user for convenient variable name matching
 */
 typedef enum {
-  ODR_HYBRID_400HZ = 0x05,   /**< 400Hz Hybrid mode */
-  ODR_HYBRID_200HZ = 0x0D,   /**< 200Hz Hybrid mode */
-  ODR_HYBRID_100HZ = 0x15,   /**< 100Hz Hybrid mode */
-  ODR_HYBRID_50HZ = 0x1D,    /**< 50Hz Hybrid mode */
-  ODR_HYBRID_25HZ = 0x25,    /**< 25Hz Hybrid mode */
-  ODR_HYBRID_6_25HZ = 0x2D,  /**< 6.25Hz Hybrid mode */
-  ODR_HYBRID_3_125HZ = 0x35, /**< 3.125Hz Hybrid mode */
-  ODR_HYBRID_0_7813HZ = 0x3D /**< 0.7813Hz Hybrid mode */
-} fxos8700HybridODR_t;
+  ODR_800HZ,    /**< 800Hz, only available in accel/mag-only modes */
+  ODR_400HZ,    /**< 400Hz, available in all modes */
+  ODR_200HZ,    /**< 200Hz, available in all modes */
+  ODR_100HZ,    /**< 100Hz, available in all modes */
+  ODR_50HZ,     /**< 50Hz, available in all modes */
+  ODR_25HZ,     /**< 25Hz, only available in hybrid mode */
+  ODR_12_5HZ,   /**< 12.5Hz, only available in accel/mag-only modes */
+  ODR_6_25HZ,   /**< 6.25Hz, available in all modes */
+  ODR_3_125HZ,  /**< 3.125Hz, only available in hybrid mode */
+  ODR_1_5625HZ, /**< 3.125Hz, only available in accel/mag-only modes */
+  ODR_0_7813HZ, /**< 0.7813Hz, only available in hybrid mode */
+} fxos8700ODR_t;
+
+/*!
+    Output Data Rates (ODRs) available for accel/mag-only modes, type array
+    of user set fxos8700ODR_t
+*/
+const fxos8700ODR_t ACCEL_MAG_ONLY_AVAILABLE_ODRs[] = {
+    ODR_800HZ,    /**< 800Hz, only available in accel/mag-only modes */
+    ODR_400HZ,    /**< 400Hz, available in all modes */
+    ODR_200HZ,    /**< 200Hz, available in all modes */
+    ODR_100HZ,    /**< 100Hz, available in all modes */
+    ODR_50HZ,     /**< 50Hz, available in all modes */
+    ODR_12_5HZ,   /**< 12.5Hz, only available in accel/mag-only modes */
+    ODR_6_25HZ,   /**< 6.25Hz, available in all modes */
+    ODR_1_5625HZ, /**< 3.125Hz, only available in accel/mag-only modes */
+};
+
+/*!
+    Output Data Rates (ODRs) available for hybrid mode, type array of user
+    set fxos8700ODR_t
+*/
+const fxos8700ODR_t HYBRID_AVAILABLE_ODRs[] = {
+    ODR_400HZ,    /**< 400Hz, available in all modes */
+    ODR_200HZ,    /**< 200Hz, available in all modes */
+    ODR_100HZ,    /**< 100Hz, available in all modes */
+    ODR_50HZ,     /**< 50Hz, available in all modes */
+    ODR_25HZ,     /**< 25Hz, only available in hybrid mode */
+    ODR_6_25HZ,   /**< 6.25Hz, available in all modes */
+    ODR_3_125HZ,  /**< 3.125Hz, only available in hybrid mode */
+    ODR_0_7813HZ, /**< 0.7813Hz, only available in hybrid mode */
+};
+
+/*!
+    Output Data Rate (ODR) settings to write to the dr[2:0] bits in
+    CTRL_REG_1, array type to pass the index from available accel/mag-only
+    and hyrbrid modes
+*/
+const uint16_t ODR_drBits[] = {
+    0x00, /**< dr=0b000. 800Hz accel/mag-only modes, 400Hz hyrbid mode */
+    0x08, /**< dr=0b001. 400Hz accel/mag-only modes, 200Hz hyrbid mode */
+    0x10, /**< dr=0b010. 200Hz accel/mag-only modes, 100Hz hyrbid mode */
+    0x18, /**< dr=0b011. 100Hz accel/mag-only modes, 50Hz hyrbid mode */
+    0x20, /**< dr=0b100. 50Hz accel/mag-only modes, 25Hz hyrbid mode */
+    0x28, /**< dr=0b101. 12.5Hz accel/mag-only modes, 6.25Hz hyrbid mode */
+    0x30, /**< dr=0b110. 6.25Hz accel/mag-only modes, 3.125Hz hyrbid mode */
+    0x38, /**< dr=0b111. 1.5625Hz accel/mag-only modes, 0.7813Hz hyrbid mode */
+};
 /*=========================================================================*/
 
 /*=========================================================================
@@ -111,10 +186,28 @@ typedef enum {
 /*=========================================================================*/
 
 /*=========================================================================
-    RAW GYROSCOPE DATA TYPE
+    OPTIONAL MAGNETOMETER OVERSAMPLING SETTINGS
     -----------------------------------------------------------------------*/
 /*!
-    @brief  Raw (integer) values from the gyroscope sensor.
+    Range settings for the accelerometer sensor.
+*/
+typedef enum {
+  MAG_OSR_0 = 0x00, /**< Mag oversampling ratio = 0 */
+  MAG_OSR_1 = 0x04, /**< Mag oversampling ratio = 1 */
+  MAG_OSR_2 = 0x08, /**< Mag oversampling ratio = 2 */
+  MAG_OSR_3 = 0x0C, /**< Mag oversampling ratio = 3 */
+  MAG_OSR_4 = 0x10, /**< Mag oversampling ratio = 4 */
+  MAG_OSR_5 = 0x14, /**< Mag oversampling ratio = 5 */
+  MAG_OSR_6 = 0x18, /**< Mag oversampling ratio = 6 */
+  MAG_OSR_7 = 0x1C, /**< Mag oversampling ratio = 7 */
+} fxos8700MagOSR_t;
+/*=========================================================================*/
+
+/*=========================================================================
+    RAW 3DOF SENSOR DATA TYPE
+    -----------------------------------------------------------------------*/
+/*!
+    @brief  Raw (integer) values from a 3dof sensor.
 */
 typedef struct {
   int16_t x; /**< Raw int16_t value from the x axis */
@@ -171,7 +264,7 @@ public:
   bool begin(uint8_t addr = 0x1F, TwoWire *wire = &Wire);
 
   bool getEvent(sensors_event_t *accel);
-  void getSensor(sensor_t *accel);
+  void getSensor(sensor_t *singleSensorEvent);
   bool getEvent(sensors_event_t *accel, sensors_event_t *mag);
   void getSensor(sensor_t *accel, sensor_t *mag);
   void standby(boolean standby);
@@ -188,19 +281,27 @@ public:
       NULL; ///< Accelerometer data object
   Adafruit_FXOS8700_Magnetometer *mag_sensor = NULL; ///< Mag data object
 
+  void setSensorMode(fxos8700SensorMode_t mode);
+  fxos8700SensorMode_t getSensorMode();
+
   void setAccelRange(fxos8700AccelRange_t range);
   fxos8700AccelRange_t getAccelRange();
 
-  void setHybridODR(fxos8700HybridODR_t rate);
-  fxos8700HybridODR_t getHybridODR();
+  void setOutputDataRate(fxos8700ODR_t rate);
+  fxos8700ODR_t getOutputDataRate();
+
+  void setMagOversamplingRatio(fxos8700MagOSR_t ratio);
+  fxos8700MagOSR_t getMagOversamplingRatio();
 
 protected:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
 
 private:
   bool initialize();
+  fxos8700SensorMode_t _mode = HYBRID_MODE;
   fxos8700AccelRange_t _range = ACCEL_RANGE_2G;
-  fxos8700HybridODR_t _rate = ODR_HYBRID_100HZ;
+  fxos8700ODR_t _rate = ODR_100HZ;
+  fxos8700MagOSR_t _ratio = MAG_OSR_7;
   int32_t _accelSensorID;
   int32_t _magSensorID;
 };

--- a/Adafruit_FXOS8700.h
+++ b/Adafruit_FXOS8700.h
@@ -82,6 +82,25 @@ typedef enum {
     OPTIONAL SPEED SETTINGS
     -----------------------------------------------------------------------*/
 /*!
+    Output Data Rate (ODR) settings for the overall FXOS8700 sensor.
+    Maintains lnoise and active bits as 1
+*/
+typedef enum {
+  ODR_HYBRID_400HZ = 0x05,    /**< 400Hz Hybrid mode */
+  ODR_HYBRID_200HZ = 0x0D,    /**< 200Hz Hybrid mode */
+  ODR_HYBRID_100HZ = 0x15,    /**< 100Hz Hybrid mode */
+  ODR_HYBRID_50HZ = 0x1D,     /**< 50Hz Hybrid mode */
+  ODR_HYBRID_25HZ = 0x25,     /**< 25Hz Hybrid mode */
+  ODR_HYBRID_6_25HZ = 0x2D,   /**< 6.25Hz Hybrid mode */
+  ODR_HYBRID_3_125HZ = 0x35,  /**< 3.125Hz Hybrid mode */
+  ODR_HYBRID_0_7813HZ = 0x3D  /**< 0.7813Hz Hybrid mode */
+} fxos8700HybridODR_t;
+/*=========================================================================*/
+
+/*=========================================================================
+    OPTIONAL RANGE SETTINGS
+    -----------------------------------------------------------------------*/
+/*!
     Range settings for the accelerometer sensor.
 */
 typedef enum {
@@ -172,12 +191,16 @@ public:
   void setAccelRange(fxos8700AccelRange_t range);
   fxos8700AccelRange_t getAccelRange();
 
+  void setHybridODR(fxos8700HybridODR_t rate);
+  fxos8700HybridODR_t getHybridODR();
+
 protected:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
 
 private:
   bool initialize();
   fxos8700AccelRange_t _range = ACCEL_RANGE_2G;
+  fxos8700HybridODR_t _rate = ODR_HYBRID_100HZ;
   int32_t _accelSensorID;
   int32_t _magSensorID;
 };

--- a/Adafruit_FXOS8700.h
+++ b/Adafruit_FXOS8700.h
@@ -192,14 +192,14 @@ typedef enum {
     Range settings for the accelerometer sensor.
 */
 typedef enum {
-  MAG_OSR_0 = 0x00, /**< Mag oversampling ratio = 0 */
-  MAG_OSR_1 = 0x04, /**< Mag oversampling ratio = 1 */
-  MAG_OSR_2 = 0x08, /**< Mag oversampling ratio = 2 */
-  MAG_OSR_3 = 0x0C, /**< Mag oversampling ratio = 3 */
-  MAG_OSR_4 = 0x10, /**< Mag oversampling ratio = 4 */
-  MAG_OSR_5 = 0x14, /**< Mag oversampling ratio = 5 */
-  MAG_OSR_6 = 0x18, /**< Mag oversampling ratio = 6 */
-  MAG_OSR_7 = 0x1C, /**< Mag oversampling ratio = 7 */
+  MAG_OSR_0, /**< Mag oversampling ratio = 0 */
+  MAG_OSR_1, /**< Mag oversampling ratio = 1 */
+  MAG_OSR_2, /**< Mag oversampling ratio = 2 */
+  MAG_OSR_3, /**< Mag oversampling ratio = 3 */
+  MAG_OSR_4, /**< Mag oversampling ratio = 4 */
+  MAG_OSR_5, /**< Mag oversampling ratio = 5 */
+  MAG_OSR_6, /**< Mag oversampling ratio = 6 */
+  MAG_OSR_7, /**< Mag oversampling ratio = 7 */
 } fxos8700MagOSR_t;
 /*=========================================================================*/
 

--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -77,6 +77,9 @@ void setup(void) {
   /* Set accelerometer range (optional, default is 2G) */
   // accelmag.setAccelRange(ACCEL_RANGE_8G);
 
+  /* Set hybrid (accel & mag) output data rate (optional, default is 100Hz) */
+  // accelmag.setHybridODR(ODR_HYBRID_400HZ);
+
   /* Display some basic information on this sensor */
   displaySensorDetails();
 }

--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -77,8 +77,14 @@ void setup(void) {
   /* Set accelerometer range (optional, default is 2G) */
   // accelmag.setAccelRange(ACCEL_RANGE_8G);
 
-  /* Set hybrid (accel & mag) output data rate (optional, default is 100Hz) */
-  // accelmag.setHybridODR(ODR_HYBRID_400HZ);
+  /* Set the sensor mode (optional, default is hybrid mode) */
+  // accelmag.setSensorMode(ACCEL_ONLY_MODE);
+
+  /* Set the magnetometer's oversampling ratio (optional, default is 7) */
+  // accelmag.setMagOversamplingRatio(MAG_OSR_7);
+
+  /* Set the output data rate (optional, default is 100Hz) */
+  // accelmag.setOutputDataRate(ODR_400HZ);
 
   /* Display some basic information on this sensor */
   displaySensorDetails();


### PR DESCRIPTION
Hi there!

This PR adds some config settings for the hybrid output data rate (ODR).

---Scope---
A getter/setter was created for the hybrid ODR (copied directly from the setAccelRange() and getAccelRange() functions) to allow configuration for accel+mag sampling rates.

---Limitations---
The rate param for setHybridODR() is assumed to also be an 8 bit number, as configured in the custom fxos8700HybridODR_t type. It also includes: 2x aslp_rate, lnoise, f_read, and active bits which are assumed to be 00, 1, 0, 1 for all cases. For clarity, the rate settings follow the structure 0b00xxx101 and only edit xxx. Assuming the last bit is always 1, it's switched to 0 inside setHybridODR() to maintain standby mode during configuration.

---Examples/Tests---
I've added a call to setHybridODR() after your mock setAccelRange() setting in /examples/sensorapi/sensorapi.ino. It functions as expected and the configuration settings work.

Let me know if you'd like me to make any changes,
Ben